### PR TITLE
Fix httpx usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Now enjoy access to a Terragraph Development image.
 ```ini
 [tgsign]
 api_id = foo
-api_secret = bar
+api_token = bar
 public_key_file = /home/cooper/.ssh/id_25519.pub
 username = cooper
 ```


### PR DESCRIPTION
- Use context maanger so we always cleanup connections
- Remove uneeded list from JSON
- Use correct api_token and not api_secret

Tests: Fix unit tests and run manually